### PR TITLE
Passes Along Cookies When Uploading Files

### DIFF
--- a/lib/wallaby/selenium.ex
+++ b/lib/wallaby/selenium.ex
@@ -386,7 +386,12 @@ defmodule Wallaby.Selenium do
     zip64 = make_file(filename)
     endpoint = element.session_url <> "/file"
 
-    case Wallaby.HTTPClient.request(:post, endpoint, %{file: zip64}) do
+    case Wallaby.HTTPClient.request(
+          :post,
+          endpoint,
+          %{file: zip64},
+          cookies: element.cookies
+        ) do
       {:ok, response, _cookies} ->
         Map.fetch!(response, "value")
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Wallaby.Mixfile do
   @moduledoc false
   use Mix.Project
 
-  @version "0.1.6"
+  @version "0.1.7"
   @drivers ~w(selenium chrome)
   @selected_driver System.get_env("WALLABY_DRIVER")
   @maintainers [


### PR DESCRIPTION
The cookies (that return us to the same Selenium server) were not being sent when performing an upload. This is an attempt to fix that.